### PR TITLE
Don't allow duplicate accounts even if one of them is deprecated 

### DIFF
--- a/api/services/account/store_getaccountbyname.go
+++ b/api/services/account/store_getaccountbyname.go
@@ -24,7 +24,6 @@ func (s *PostgresAccountStore) GetAccountByName(ctx context.Context, name string
 			where 
 				user_id = $1
 				and name ~* $2
-				and is_deprecated = false
 		`, accountColumns),
 		userId,
 		namePattern,

--- a/tests/integration/testcases/account/createaccount.go
+++ b/tests/integration/testcases/account/createaccount.go
@@ -33,7 +33,7 @@ func CreateAccountTestCases(t *testing.T, userId int, email string) []testcases.
 				Name:          "VAN002",
 				Tax_shelter:   "TAXABLE",
 				Institution:   "Vanguard",
-				Is_deprecated: false,
+				Is_deprecated: true,
 			},
 			ExpectedStatusCode: fiber.StatusCreated,
 		},
@@ -82,7 +82,7 @@ func CreateAccountTestCases(t *testing.T, userId int, email string) []testcases.
 		{
 			Title: "409",
 			Payload: account.CreateAccountPayload{
-				Name:        "vAn001",
+				Name:        "vAn002",
 				Tax_shelter: "TAXABLE",
 				Institution: "Vanguard",
 			},

--- a/tests/integration/testcases/account/getaccounts.go
+++ b/tests/integration/testcases/account/getaccounts.go
@@ -143,11 +143,11 @@ func GetAccountsTestCases(t *testing.T, userId int, email string) []testcases.Te
 			Route:              "/api/v2/accounts?is_deprecated=true",
 			ExpectedStatusCode: fiber.StatusOK,
 			ExpectedResponse: GetAccountsExpectedResponse{
-				Accounts: 3,
+				Accounts: 4,
 				Pagination: types.PaginationMetadata{
 					Current_page: 1,
 					Page_size:    50,
-					Total_items:  3,
+					Total_items:  4,
 				},
 			},
 		},

--- a/tests/integration/testcases/account/updateaccount.go
+++ b/tests/integration/testcases/account/updateaccount.go
@@ -32,10 +32,9 @@ func UpdateAccountsTestCases(t *testing.T, accountId int, userId int, email stri
 			Title:       "200 No Description",
 			ParameterId: accountId,
 			Payload: account.UpdateAccountPayload{
-				Name:          "VAN032",
-				Tax_shelter:   "TAXABLE",
-				Institution:   "Vanguard",
-				Is_deprecated: false,
+				Name:        "VAN032",
+				Tax_shelter: "TAXABLE",
+				Institution: "Vanguard",
 			},
 			ExpectedStatusCode: fiber.StatusOK,
 		},


### PR DESCRIPTION
Closes #43 

The final in the deprecation change series.